### PR TITLE
Add Homebrew cask for GraalVM Community Edition

### DIFF
--- a/Casks/graalvm-ce.rb
+++ b/Casks/graalvm-ce.rb
@@ -1,0 +1,29 @@
+cask "graalvm-ce" do
+  version "19.1.1"
+  sha256 "85711322866ddacda88d3a592c76520188b3d7c40b6c39cd9943856e72eb6c72"
+
+  JVMS_DIR = "/Library/Java/JavaVirtualMachines"
+  TARGET_DIR = "#{JVMS_DIR}/graalvm-ce-#{version}"
+
+  name "GraalVM Community Edition"
+  url "https://github.com/oracle/graal/releases/download/vm-#{version}/graalvm-ce-darwin-amd64-#{version}.tar.gz"
+  homepage 'https://www.graalvm.org'
+  appcast 'https://github.com/oracle/graal/releases.atom'
+
+  artifact "graalvm-ce-#{version}", target: TARGET_DIR
+
+  caveats <<~EOS
+    Installing GraalVM CE in #{JVMS_DIR} requires root permissions.
+    You may be asked to enter your password to proceed.
+
+    To use GraalVM CE, you may want to change your `JAVA_HOME`:
+      export JAVA_HOME=#{TARGET_DIR}/Contents/Home
+
+    or you may want to add its `bin` directory to your `PATH`:
+      export PATH=#{TARGET_DIR}/Contents/Home/bin:"$PATH"
+
+    GraalVM CE is licensed under the GPL 2 with Classpath exception:
+      https://github.com/oracle/graal/blob/master/LICENSE
+
+  EOS
+end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Homebrew Tap for GraalVM
 
+Run the following command to install GraalVM Community Edition with [Homebrew]:
+
+```bash
+brew cask install graalvm/tap/graalvm-ce
+```
+
+[Homebrew]: https://brew.sh/


### PR DESCRIPTION
This is what the installation looks like:

```
$ brew cask install graalvm/tap/graalvm-ce
==> Caveats
Installing GraalVM CE in /Library/Java/JavaVirtualMachines requires root permissions.
You may be asked to enter your password to proceed.

To use GraalVM CE, you may want to change your `JAVA_HOME`:
  export JAVA_HOME=/Library/Java/JavaVirtualMachines/graalvm-ce-19.1.1/Contents/Home

or you may want to add its `bin` directory to your `PATH`:
  export PATH=/Library/Java/JavaVirtualMachines/graalvm-ce-19.1.1/Contents/Home/bin:"$PATH"

GraalVM CE is licensed under the GPL 2 with Classpath exception:
  https://github.com/oracle/graal/blob/master/LICENSE

==> Satisfying dependencies
==> Downloading https://github.com/oracle/graal/releases/download/vm-19.1.1/graalvm-ce-darwin-amd64-19.1.1.tar.gz
==> Verifying SHA-256 checksum for Cask 'graalvm-ce'.
==> Installing Cask graalvm-ce
==> Moving Generic Artifact 'graalvm-ce-19.1.1' to '/Library/Java/JavaVirtualMachines/graalvm-ce-19.1.1'.
🍺  graalvm-ce was successfully installed!
```