### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,44 @@ Run one of the following commands to install GraalVM Community Edition with [Hom
 
 ```bash
 brew cask install graalvm/tap/graalvm-ce-java8
+brew cask install graalvm/tap/graalvm-ce-lts-java8
 
 brew cask install graalvm/tap/graalvm-ce-java11
+brew cask install graalvm/tap/graalvm-ce-lts-java11
 ```
 
 Once installed, these casks can be upgraded (if an update is available) with the following commands:
 
 ```bash
 brew cask upgrade graalvm/tap/graalvm-ce-java8
+brew cask upgrade graalvm/tap/graalvm-ce-lts-java8
 
 brew cask upgrade graalvm/tap/graalvm-ce-java11
+brew cask upgrade graalvm/tap/graalvm-ce-lts-java11
 ```
 
-On macOS Catalina, you may get a warning that "the developer cannot be
-verified". This check can be disabled in the "Security & Privacy"
-preferences pane or by running the following command:
-
- ` xattr -r -d com.apple.quarantine /Library/Java/JavaVirtualMachines/graalvm-ce-java8-20.0.0 `
+## How to Use
 
 To use GraalVM CE, you may want to change your `JAVA_HOME`: 
 
-`export JAVA_HOME=/Library/Java/JavaVirtualMachines/graalvm-ce-java8-20.0.0/Contents/Home`
+ `export JAVA_HOME=/Library/Java/JavaVirtualMachines/graalvm-ce-javaV-XX.Y.Z/Contents/Home`
 
 or you may want to add its `bin` directory to your `PATH`:
 
-  `export PATH=/Library/Java/JavaVirtualMachines/graalvm-ce-java8-20.0.0/Contents/Home/bin:"$PATH"`
+  `export PATH=/Library/Java/JavaVirtualMachines/graalvm-ce-javaV-XX.Y.Z/Contents/Home/bin:"$PATH"`
+
+
+## macOS Catalina Specifics
+
+On macOS Catalina, you may get a warning that "the developer cannot be
+verified". This is due to GraalVM not being signed and notarized yet.
+The check, however, can be disabled in the "Security & Privacy"
+preferences pane or by running the following command:
+
+ `xattr -r -d com.apple.quarantine /Library/Java/JavaVirtualMachines/graalvm-ce-javaV-XX.Y.Z`
+ 
+The GraalVM casks might ask you for sudo permissions to remove the
+quarantine attributes as part of the installation process.
+
 
 [Homebrew]: https://brew.sh/

--- a/README.md
+++ b/README.md
@@ -40,8 +40,5 @@ preferences pane or by running the following command:
 
  `xattr -r -d com.apple.quarantine /Library/Java/JavaVirtualMachines/graalvm-ce-javaV-XX.Y.Z`
  
-The GraalVM casks might ask you for sudo permissions to remove the
-quarantine attributes as part of the installation process.
-
 
 [Homebrew]: https://brew.sh/


### PR DESCRIPTION
This is the follow-up PR mentioned in https://github.com/graalvm/homebrew-tap/pull/19#issuecomment-629810612.

Now, however, that I've seen the identifiers, I'm not sure whether `-lts` should be used as prefix:
```
brew cask install graalvm/tap/graalvm-ce-java8
brew cask install graalvm/tap/graalvm-ce-java8-lts
```
instead of 
```
brew cask install graalvm/tap/graalvm-ce-java8
brew cask install graalvm/tap/graalvm-ce-lts-java8
```

What do you think, @dougxc?