### PR TITLE
update jdk16 to 21.2.0

### DIFF
--- a/Casks/graalvm-ce-java16.rb
+++ b/Casks/graalvm-ce-java16.rb
@@ -1,6 +1,6 @@
 cask 'graalvm-ce-java16' do
-  version '21.1.0'
-  sha256 'dafece9d03251304a6d9fc242862cfc08b85e2b8921d3b019a8a19b95af78e2c'
+  version '21.2.0'
+  sha256 '833412a6e26c26ae3de37bd42e889f60d7a7651122c6d52741ed0d7f56a0460f'
 
   JVMS_DIR = '/Library/Java/JavaVirtualMachines'.freeze
   TARGET_DIR = "#{JVMS_DIR}/#{cask}-#{version}".freeze


### PR DESCRIPTION
This PR updates the graalvm-ce-jdk16 to v21.2.0

A simple way to verify the sha256 value. Assuming you have Github CLI installed and configured, run:

```
gh release download vm-21.2.0 \
  --repo graalvm/graalvm-ce-builds \
  --pattern graalvm-ce-java16-darwin-amd64-21.2.0.tar.gz 2> /dev/null; \
sha256sum graalvm-ce-java16-darwin-amd64-21.2.0.tar.gz; \
rm -f graalvm-ce-java16-darwin-amd64-21.2.0.tar.gz
```
