### PR TITLE
Delete `appcast` stanzas

### DIFF
--- a/Casks/graalvm-ce-java11.rb
+++ b/Casks/graalvm-ce-java11.rb
@@ -10,7 +10,6 @@ cask "graalvm-ce-java11" do
 
   # github.com/graalvm/graalvm-ce-builds was verified as official when first introduced to the cask
   url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-#{version}/#{cask}-darwin-#{arch}-#{version}.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "GraalVM Community Edition (Java 11)"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-ce-java16.rb
+++ b/Casks/graalvm-ce-java16.rb
@@ -7,7 +7,6 @@ cask "graalvm-ce-java16" do
 
   # github.com/graalvm/graalvm-ce-builds was verified as official when first introduced to the cask
   url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-#{version}/#{cask}-darwin-amd64-#{version}.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "GraalVM Community Edition (Java 16)"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-ce-java17.rb
+++ b/Casks/graalvm-ce-java17.rb
@@ -10,7 +10,6 @@ cask "graalvm-ce-java17" do
 
   # github.com/graalvm/graalvm-ce-builds was verified as official when first introduced to the cask
   url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-#{version}/#{cask}-darwin-#{arch}-#{version}.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "GraalVM Community Edition (Java 17)"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-ce-java19.rb
+++ b/Casks/graalvm-ce-java19.rb
@@ -10,7 +10,6 @@ cask "graalvm-ce-java19" do
 
   # github.com/graalvm/graalvm-ce-builds was verified as official when first introduced to the cask
   url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-#{version}/#{cask}-darwin-#{arch}-#{version}.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "GraalVM Community Edition (Java 19)"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-ce-java8.rb
+++ b/Casks/graalvm-ce-java8.rb
@@ -7,7 +7,6 @@ cask "graalvm-ce-java8" do
 
   # github.com/graalvm/graalvm-ce-builds was verified as official when first introduced to the cask
   url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-#{version}/#{cask}-darwin-amd64-#{version}.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "GraalVM Community Edition (Java 8)"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-ce-lts-java11.rb
+++ b/Casks/graalvm-ce-lts-java11.rb
@@ -7,7 +7,6 @@ cask "graalvm-ce-lts-java11" do
 
   # github.com/graalvm/graalvm-ce-builds was verified as official when first introduced to the cask
   url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-#{version}/graalvm-ce-java11-darwin-amd64-#{version}.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "GraalVM Community Edition, LTS (Java 11)"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-ce-lts-java8.rb
+++ b/Casks/graalvm-ce-lts-java8.rb
@@ -7,7 +7,6 @@ cask "graalvm-ce-lts-java8" do
 
   # github.com/graalvm/graalvm-ce-builds was verified as official when first introduced to the cask
   url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-#{version}/graalvm-ce-java8-darwin-amd64-#{version}.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "GraalVM Community Edition, LTS (Java 8)"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-community-jdk17.rb
+++ b/Casks/graalvm-community-jdk17.rb
@@ -11,7 +11,6 @@ cask "graalvm-community-jdk17" do
 
   # github.com/graalvm/graalvm-ce-builds was verified as official when first introduced to the cask
   url "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-#{version}/graalvm-community-jdk-#{version}_macos-#{arch}_bin.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "GraalVM Community Edition for JDK 17"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-community-jdk20.rb
+++ b/Casks/graalvm-community-jdk20.rb
@@ -11,7 +11,6 @@ cask "graalvm-community-jdk20" do
 
   # github.com/graalvm/graalvm-ce-builds was verified as official when first introduced to the cask
   url "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-#{version}/graalvm-community-jdk-#{version}_macos-#{arch}_bin.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "GraalVM Community Edition for JDK 20"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-jdk17.rb
+++ b/Casks/graalvm-jdk17.rb
@@ -11,7 +11,6 @@ cask "graalvm-jdk17" do
 
   # download.oracle.com was verified as official when first introduced to the cask
   url "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-#{version}_macos-#{arch}_bin.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "Oracle GraalVM for JDK 17"
   homepage "https://www.graalvm.org/"
 

--- a/Casks/graalvm-jdk20.rb
+++ b/Casks/graalvm-jdk20.rb
@@ -11,7 +11,6 @@ cask "graalvm-jdk20" do
 
   # download.oracle.com was verified as official when first introduced to the cask
   url "https://download.oracle.com/graalvm/20/archive/graalvm-jdk-#{version}_macos-#{arch}_bin.tar.gz"
-  appcast "https://github.com/oracle/graal/releases.atom"
   name "Oracle GraalVM for JDK 20"
   homepage "https://www.graalvm.org/"
 


### PR DESCRIPTION
These have been deprecated for a while, and have now started causing errors on attempting to use the casks for anything.